### PR TITLE
Cleanup the README.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,13 @@
+# Installation
+
+## Installing Ruby & Jekyll
+
+If this is your first time using Jekyll, please follow the [Jekyll docs](https://jekyllrb.com/docs/installation/) and make sure your local environment (including Ruby) is setup correctly.
+
+* * *
+
+# Deployment
+
+To run the theme locally, navigate to the theme directory and run `bundle install` to install the dependencies, then run `jekyll serve` or `bundle exec jekyll serve` to start the Jekyll server.
+
+I would recommend checking the [Deployment Methods](https://jekyllrb.com/docs/deployment-methods/) page on Jekyll website.

--- a/README.md
+++ b/README.md
@@ -1,73 +1,12 @@
-# Mria is a multipurpose Jekyll blog theme.
+# 🧇 Commit Waffles
 
-Mria is a high-quality multipurpose Jekyll theme with a unique style and clean code. You can use Mria for multipurpose like blog, magazine, portfolio, etc. This theme is fully responsive, and it looks good on all types of screens and devices. If you’re looking for a theme that is clean, high performance, and simple, the Mria theme is exactly what you’re looking for then.
 
-* * *
+A blog of ramblings, stories and insights by brothers Jeremy and Martin Pitt, web developers based in London, UK.
 
-### Demo
 
-Check the theme in action [Live Demo](https://mria.netlify.app/) |
-[Artem Sheludko](https://jekyllthemes.io/developers/artem-sheludko)
+---
 
-* * *
+Commit Waffles is hosted via [GitHub Pages](https://pages.github.com/) and uses [Jekyll](https://jekyllrb.com/) with a modified [Mria theme](https://jekyllthemes.io/theme/mria-multipurpose-jekyll-theme).
 
-### Theme features
+If you want to install and deploy, please refer to [INSTALL.md](INSTALL.md).
 
-- Works with GitHub Pages (host it for free)
-- Dark and light mode
-- No jQuery, only vanilla JS
-- 100% responsive Design
-- Clean and Modern Code
-- Optimized for mobile devices
-- Section featured posts
-- Section blog
-- Section videos
-- Section tag
-- Super fast performance ⚡⚡⚡
-- Social sharing buttons
-- Scroll to top button
-- Syntax highlighting (supports the Jekyll syntax highlighter)
-- Compatible with modern browsers
-- Medium style image zoom
-- Image Lazy loading
-- Image gallery
-- Tag page
-- Author page
-- Custom logo support
-- Support for multiple authors
-- Supports video posts
-- Supports contact form (Formspree)
-- Supports MailChimp newsletter
-- Supports Disqus comments
-- Supports Google Analytics
-- Ionicons icons
-- Free Google Fonts
-- Free Updates & Support
-
-* * *
-
-### Installation
-
-#### Installing Ruby & Jekyll
-
-If this is your first time using Jekyll, please follow the [Jekyll docs](https://jekyllrb.com/docs/installation/) and make sure your local environment (including Ruby) is setup correctly.
-
-* * *
-
-### Deployment
-
-To run the theme locally, navigate to the theme directory and run `bundle install` to install the dependencies, then run `jekyll serve` or `bundle exec jekyll serve` to start the Jekyll server.
-
-I would recommend checking the [Deployment Methods](https://jekyllrb.com/docs/deployment-methods/) page on Jekyll website.
-
-* * *
-
-### Documentation
-
-Before using the Mria theme, please read the attached documentation.
-
-* * *
-
-### Support
-
-<p>If you have any questions, please feel free to contact me by mail <a href="mailto:hi.artemsheludko@gmail.com">Contact</a><p>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,22 @@ A blog of ramblings, stories and insights by brothers Jeremy and Martin Pitt, we
 
 ---
 
-Commit Waffles is hosted via [GitHub Pages](https://pages.github.com/) and uses [Jekyll](https://jekyllrb.com/) with a modified [Mria theme](https://jekyllthemes.io/theme/mria-multipurpose-jekyll-theme).
+
+## How to contribute
+
+If there are typos & bugs on the website, feel free to pop open an issue to let us know. Please share a URL (_Copy Link to Highlight_) and small screenshot in the issue if it helps with context.
+
+At some point we want to look at having guests posts but we don't know how that will look like yet.
+
+
+### Install
 
 If you want to install and deploy, please refer to [INSTALL.md](INSTALL.md).
+
+
+## Acknowledgements
+
+Commit Waffles is hosted via [GitHub Pages](https://pages.github.com/) and uses [Jekyll](https://jekyllrb.com/) with a modified [Mria theme](https://jekyllthemes.io/theme/mria-multipurpose-jekyll-theme).
+
+
 


### PR DESCRIPTION
Cleaned up the README.md and split up the installation instructions to keep it tidy.

We can add over time as we think of what to add to the README and sections to have.

Particularly what I would like to add is a logo / image header.

There's more reading and examples you can find here:
https://github.com/matiassingers/awesome-readme#articles
